### PR TITLE
feat: Update user filtering method to use RoleType instead of String …

### DIFF
--- a/src/main/java/com/regisx001/blog/repositories/UserRepository.java
+++ b/src/main/java/com/regisx001/blog/repositories/UserRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.regisx001.blog.domain.entities.User;
+import com.regisx001.blog.domain.entities.RoleType;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, UUID> {
@@ -39,7 +40,7 @@ public interface UserRepository extends JpaRepository<User, UUID> {
                         "AND (:enabled IS NULL OR u.enabled = :enabled)")
         Page<User> findAllBySearchAndRoleAndEnabled(
                         @Param("searchTerm") String searchTerm,
-                        @Param("role") String role,
+                        @Param("role") RoleType role,
                         @Param("enabled") Boolean enabled,
                         Pageable pageable);
 

--- a/src/main/java/com/regisx001/blog/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/regisx001/blog/services/impl/UserServiceImpl.java
@@ -92,8 +92,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public Page<Detailed> getAllUsersByFilters(String searchTermsn, RoleType role, Boolean enabled, Pageable pageable) {
-        String roleString = role != null ? role.name() : null;
-        return userRepository.findAllBySearchAndRoleAndEnabled(searchTermsn, roleString, enabled, pageable)
+        return userRepository.findAllBySearchAndRoleAndEnabled(searchTermsn, role, enabled, pageable)
                 .map(userMapper::toDetailedDto);
     }
 


### PR DESCRIPTION
This pull request refactors the `UserRepository` and `UserServiceImpl` classes to improve type safety by replacing the use of `String` for roles with the `RoleType` enum. This change ensures better validation and reduces potential errors when working with user roles.

### Type Safety Improvements:

* [`src/main/java/com/regisx001/blog/repositories/UserRepository.java`](diffhunk://#diff-87321ab33efcb665a3632872b96e9e12b8c55c626aa0950e6df6854421f2054dL42-R43): Updated the `findAllBySearchAndRoleAndEnabled` method to use the `RoleType` enum instead of a `String` for the `role` parameter.
* [`src/main/java/com/regisx001/blog/repositories/UserRepository.java`](diffhunk://#diff-87321ab33efcb665a3632872b96e9e12b8c55c626aa0950e6df6854421f2054dR14): Added an import for the `RoleType` enum to support the updated method signature.

### Service Layer Adjustments:

* [`src/main/java/com/regisx001/blog/services/impl/UserServiceImpl.java`](diffhunk://#diff-e4bee310c1686d4950b50c64d3ec7607283ed1fc6a27582b39c185e59fefc87cL95-R95): Updated the `getAllUsersByFilters` method to pass the `RoleType` enum directly to the repository method, removing the need for manual conversion to a string.…for role parameter