### PR TITLE
feat: Add convert article to draft functionality; implement draftArti…

### DIFF
--- a/src/main/java/com/regisx001/blog/controllers/ArticleController.java
+++ b/src/main/java/com/regisx001/blog/controllers/ArticleController.java
@@ -113,6 +113,11 @@ public class ArticleController {
         return ResponseEntity.ok(articleService.unpublishArticle(id, userDetails.getId()));
     }
 
+    @PostMapping("/convert-draft/{id}")
+    public ResponseEntity<?> convertArticleToDraft(@PathVariable UUID id, @AuthenticationPrincipal User userDetails) {
+        return ResponseEntity.ok(articleService.draftArticle(id, userDetails));
+    }
+
     @GetMapping(path = "/for-review")
     public ResponseEntity<?> getReviewedArticlesByUser(@AuthenticationPrincipal User user, Pageable pageable) {
         return ResponseEntity.ok(articleService.getReviewArticlesByUser(user.getId(), pageable));

--- a/src/main/java/com/regisx001/blog/controllers/admin/ArticleAdminController.java
+++ b/src/main/java/com/regisx001/blog/controllers/admin/ArticleAdminController.java
@@ -95,6 +95,11 @@ public class ArticleAdminController {
         return ResponseEntity.ok(articleService.unpublishArticle(id, userDetails.getId()));
     }
 
+    @PostMapping("/convert-draft/{id}")
+    public ResponseEntity<?> convertArticleToDraft(@PathVariable UUID id, @AuthenticationPrincipal User userDetails) {
+        return ResponseEntity.ok(articleService.draftArticle(id, userDetails));
+    }
+
     @Transactional
     @GetMapping("/export")
     public void exportArticlesToCsv(HttpServletResponse response) throws IOException {

--- a/src/main/java/com/regisx001/blog/services/ArticleService.java
+++ b/src/main/java/com/regisx001/blog/services/ArticleService.java
@@ -50,6 +50,8 @@ public interface ArticleService {
 
     ArticleDto.Detailed rejectArticle(UUID id, ArticleDto.RejectionRequest rejectionRequest, User adminUser);
 
+    ArticleDto.Detailed draftArticle(UUID id, User user);
+
     // ============= USER-SPECIFIC OPERATIONS =============
 
     Page<ArticleDto.Draft> getUserDrafts(UUID authorId, Pageable pageable);


### PR DESCRIPTION
This pull request adds a new feature that allows articles to be converted back to draft status by both regular users and admins. The main changes include new controller endpoints for this functionality, updates to the service interface, and the implementation of the draft conversion logic with appropriate access checks.

**New "Convert to Draft" Functionality:**

* Added `POST /convert-draft/{id}` endpoint in both `ArticleController` and `ArticleAdminController` to allow users and admins to convert an article to draft status. [[1]](diffhunk://#diff-36144c60dd653871c8207b94f6340d2de2661dad7e1f3082a94cb1ec06f1181aR116-R120) [[2]](diffhunk://#diff-11f1734b06b67b38fb5a1789b553a11736cc9628e9dd973f17f07cc5454e3e21R98-R102)
* Updated `ArticleService` interface to include the new `draftArticle(UUID id, User user)` method.
* Implemented `draftArticle` in `ArticleServiceImpl` with access control: only the article owner or an admin can convert an article to draft; otherwise, an exception is thrown.…cle method in ArticleService and corresponding endpoint in ArticleController and ArticleAdminController